### PR TITLE
A11y: fix button accessibility and div for Contact Form 7

### DIFF
--- a/integrations/plugins/contact-form-7.php
+++ b/integrations/plugins/contact-form-7.php
@@ -89,8 +89,8 @@ function cmplz_contactform7_errormessage( $message, $status ) {
 			__( 'Click to accept marketing cookies and enable this form',
 				'complianz-gdpr' ) );
 		$message
-		             = '<div class="cmplz-blocked-content-notice cmplz-accept-marketing"><a href="#">'
-		               . $accept_text . '</a></div>';
+		             = '<span class="cmplz-blocked-content-notice cmplz-accept-marketing"><a href="#" role="button">'
+		               . $accept_text . '</a></span>';
 	}
 
 	return $message;


### PR DESCRIPTION
Hi,

I've fixed the accessibility of the button to accept cookies in Contact Form 7 by adding a `role="button"` attribute because it's not actually a link.

I've transformed the `<div>` into a `<span>` because the message in Contact Form 7 is supposed to be a paragraph for accessibility reasons (it's a `div` now in the official plugin - I will suggest a lot of modification to Contact Form 7 for it's accessibility too - It's a [work in progress](https://github.com/Tanaguru/cf7-tanaguru/)) so, a `div` inside a `p` is not allowed but a `span` into a `p` is allowed.