### PR TITLE
Fixed incorrect event attribute

### DIFF
--- a/class-document.php
+++ b/class-document.php
@@ -2237,7 +2237,7 @@ if ( ! class_exists( "cmplz_document" ) ) {
 
 						$(document).on("cmplzEnableScripts", cmplzEnableCustomBlockedContent);
 						function cmplzEnableCustomBlockedContent(consentData) {
-							if (consentData.consentLevel==='marketing' ){
+							if (consentData.detail==='marketing' ){
 								if (url.indexOf('cmplz_consent=1') === -1 ) {
 									if (url.indexOf('?') !== -1) {url += '&';} else {url += '?';}
 									url += 'cmplz_consent=1#cmplz_consent_area_anchor';
@@ -2252,7 +2252,7 @@ if ( ! class_exists( "cmplz_document" ) ) {
 					jQuery(document).ready(function ($) {
 						$(document).on("cmplzEnableScripts", cmplzEnableCustomBlockedContent);
 						function cmplzEnableCustomBlockedContent(consentData) {
-							if (consentData.consentLevel==='marketing' && !$("#cmplz_consent_area_anchor").length){
+							if (consentData.detail==='marketing' && !$("#cmplz_consent_area_anchor").length){
 								location.reload();
 							}
 						}


### PR DESCRIPTION
Hi,

this is a simple pull request to fix a tiny bug, which causes the link in a content placeholder to not work.

The event handler cmplzEnableScripts, which gets called when you click on the link of a content placeholder to enable cookies, tried to access the "consentLevel" attribute of the event it was given. 

That attribute however isn't set and the required information is instead contained in the "detail" attribute. For comparison see [complianz.js:L40](https://github.com/Really-Simple-Plugins/complianz-gdpr/blob/3e6208957e62945a297c87fe28ef1e0cc88b2646/assets/js/complianz.js#L40) and [complianz.js:L370](https://github.com/Really-Simple-Plugins/complianz-gdpr/blob/3e6208957e62945a297c87fe28ef1e0cc88b2646/assets/js/complianz.js#L370) where the attribute gets defined and set.

This causes the if condition to equate to false and therefore the page not be reload. From a user perspective this means the link seems to have no functionality,  as simply nothing happens when you click it. Only when the page gets manually reloaded the actual content is displayed. 