### PR TITLE
Fix link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ If you're a developer and want to help out, please feel free to contribute anywa
 
 ### Support
 
-For support we kindly ask you to start at our [support forum](https://wordpress.org/support/plugin/complianz-gdpr/) and our documentation at [complianz.io/docs/](complianz.io/docs/). If you can't find a solution, do not hesitate to ask either on the forum or log a suppor ticket.
+For support we kindly ask you to start at our [support forum](https://wordpress.org/support/plugin/complianz-gdpr/) and our documentation at [complianz.io/docs/](https://complianz.io/docs). If you can't find a solution, do not hesitate to ask either on the forum or log a suppor ticket.
 
 If you like Complianz - Please [rate us](https://wordpress.org/support/plugin/complianz-gdpr/reviews/) on WordPress.org
 


### PR DESCRIPTION
This PR adds `https://` to the link to the documentation. Without the protocol the url is treated as being relative to https://github.com/Really-Simple-Plugins/complianz-gdpr/blob/master/ giving a 404.