### PR TITLE
Add s on placeholder regex

### DIFF
--- a/class-cookie-blocker.php
+++ b/class-cookie-blocker.php
@@ -292,7 +292,7 @@ if ( ! class_exists( 'cmplz_cookie_blocker' ) ) {
 					foreach ( $markers as $marker ) {
 						$placeholder_pattern
 							= '/<(a|section|div|blockquote|twitter-widget)*[^>]*class=[\'" ]*[^>]*('
-							  . $marker . ')[\'" ].*?>/i';
+							  . $marker . ')[\'" ].*?>/is';
 						if ( preg_match_all( $placeholder_pattern, $output,
 							$matches, PREG_PATTERN_ORDER )
 						) {


### PR DESCRIPTION
If the HTML open tag is on multiple lines, the current regex doesn't work.

Example of html : 

```html
<a href="#url" class="example" data-attr1="test" data-attr2="test" data-attr2="test"
        target="_blank">
        My link
</a>
```