### PR TITLE
Elementor integration: fix YouTube video element regex.

### DIFF
--- a/integrations/plugins/elementor.php
+++ b/integrations/plugins/elementor.php
@@ -89,7 +89,7 @@ add_action( 'wp_enqueue_scripts', 'cmplz_elementor_initDomContentLoaded',PHP_INT
 function cmplz_elementor_cookieblocker( $output ){
 
 	if ( cmplz_uses_thirdparty('youtube') ) {
-		$iframe_pattern = '/elementor-widget elementor-widget-video[ |\"].*?data-settings=.*?youtube_url.*?&quot;:&quot;(.*?)&quot;/is';
+		$iframe_pattern = '/elementor-widget elementor-widget-video[ |\"][^>]+?data-settings="[^"]+?youtube_url[^;]*?&quot;:&quot;(.+?(?=&quot;))&quot;/is';
 		if ( preg_match_all( $iframe_pattern, $output, $matches, PREG_PATTERN_ORDER ) ) {
 			foreach ( $matches[0] as $key => $total_match ) {
 				$placeholder = '';
@@ -106,7 +106,7 @@ function cmplz_elementor_cookieblocker( $output ){
 		/**
 		 * Playlist
 		 */
-		$iframe_pattern = '/elementor-widget elementor-widget-video-playlist.*?data-settings=.*?youtube_url.*?&quot;:&quot;(.*?)&quot;/is';
+		$iframe_pattern = '/elementor-widget elementor-widget-video-playlist[^>]+?data-settings="[^"]+?youtube_url[^;]*?&quot;:&quot;(.+?(?=&quot;))&quot;/is';
 		if ( preg_match_all( $iframe_pattern, $output, $matches, PREG_PATTERN_ORDER ) ) {
 			foreach ( $matches[0] as $key => $total_match ) {
 				$placeholder = '';


### PR DESCRIPTION
Self-hosted/non-youtube videos could result in `.*?` matching from one Elementor video widget, across any intervening html elements, to the next YouTube widget on the page.