### PR TITLE
Accessibility fix for labels.

### DIFF
--- a/assets/css/document-grid.less
+++ b/assets/css/document-grid.less
@@ -173,9 +173,6 @@
 		  }
 		}
 
-		label>span {
-		  display:none;
-		}
 		// Center checkbox
 		.cmplz-banner-checkbox {
 		  display: flex;

--- a/cookiebanner/templates/cookiebanner.php
+++ b/cookiebanner/templates/cookiebanner.php
@@ -30,7 +30,7 @@
 										   class="cmplz-consent-checkbox cmplz-functional"
 										   size="40"
 										   value="1"/>
-									<label class="cmplz-label" for="cmplz-functional-{consent_type}" tabindex="0"><span>{category_functional}</span></label>
+									<label class="cmplz-label" for="cmplz-functional-{consent_type}" tabindex="0"><span class="screen-reader-text">{category_functional}</span></label>
 								</span>
 								<?php _e("Always active","complianz-gdpr")?>
 							</span>
@@ -55,7 +55,7 @@
 									   class="cmplz-consent-checkbox cmplz-preferences"
 									   size="40"
 									   value="1"/>
-								<label class="cmplz-label" for="cmplz-preferences-{consent_type}" tabindex="0"><span>{category_preferences}</span></label>
+								<label class="cmplz-label" for="cmplz-preferences-{consent_type}" tabindex="0"><span class="screen-reader-text">{category_preferences}</span></label>
 							</span>
 							<span class="cmplz-icon cmplz-open">
 								<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"  height="18" ><path d="M224 416c-8.188 0-16.38-3.125-22.62-9.375l-192-192c-12.5-12.5-12.5-32.75 0-45.25s32.75-12.5 45.25 0L224 338.8l169.4-169.4c12.5-12.5 32.75-12.5 45.25 0s12.5 32.75 0 45.25l-192 192C240.4 412.9 232.2 416 224 416z"/></svg>
@@ -78,7 +78,7 @@
 									   class="cmplz-consent-checkbox cmplz-statistics"
 									   size="40"
 									   value="1"/>
-								<label class="cmplz-label" for="cmplz-statistics-{consent_type}" tabindex="0"><span>{category_statistics}</span></label>
+								<label class="cmplz-label" for="cmplz-statistics-{consent_type}" tabindex="0"><span class="screen-reader-text">{category_statistics}</span></label>
 							</span>
 							<span class="cmplz-icon cmplz-open">
 								<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"  height="18" ><path d="M224 416c-8.188 0-16.38-3.125-22.62-9.375l-192-192c-12.5-12.5-12.5-32.75 0-45.25s32.75-12.5 45.25 0L224 338.8l169.4-169.4c12.5-12.5 32.75-12.5 45.25 0s12.5 32.75 0 45.25l-192 192C240.4 412.9 232.2 416 224 416z"/></svg>
@@ -101,7 +101,7 @@
 									   class="cmplz-consent-checkbox cmplz-marketing"
 									   size="40"
 									   value="1"/>
-								<label class="cmplz-label" for="cmplz-marketing-{consent_type}" tabindex="0"><span>{category_marketing}</span></label>
+								<label class="cmplz-label" for="cmplz-marketing-{consent_type}" tabindex="0"><span class="screen-reader-text">{category_marketing}</span></label>
 							</span>
 							<span class="cmplz-icon cmplz-open">
 								<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"  height="18" ><path d="M224 416c-8.188 0-16.38-3.125-22.62-9.375l-192-192c-12.5-12.5-12.5-32.75 0-45.25s32.75-12.5 45.25 0L224 338.8l169.4-169.4c12.5-12.5 32.75-12.5 45.25 0s12.5 32.75 0 45.25l-192 192C240.4 412.9 232.2 416 224 416z"/></svg>


### PR DESCRIPTION
Fix for the “form elements must have labels” accessibility issue. Instead of hiding the label content for all users, only hide it for visual display, but let it be read by screen-readers. You will need to recompile document-grid.less.

Another, probably more elegant fix would be to put the `<label>` element inside or in place of the `<span class="cmplz-category-title">` and style it accordingly. This would avoid a repetition of the current type of cookie for screen readers.