### PR TITLE
Allow Contact Form 7 5.7+ integration and use recaptcha placeholder w…

### DIFF
--- a/integrations/plugins/contact-form-7.php
+++ b/integrations/plugins/contact-form-7.php
@@ -142,14 +142,18 @@ function cmplz_contactform7_dependencies( $tags ) {
 
 add_filter( 'cmplz_known_script_tags', 'cmplz_contactform7_script' );
 function cmplz_contactform7_script( $tags ) {
-	if (defined('WPCF7_VERSION') && version_compare(WPCF7_VERSION, 5.4, '>=')) return $tags;
+	if ((defined('WPCF7_VERSION') && version_compare(WPCF7_VERSION, 5.4, '>=')) && (!class_exists('IQFix_WPCF7_Deity'))) return $message;
 
 	$service = WPCF7_RECAPTCHA::get_instance();
 	if (cmplz_get_value('block_recaptcha_service') === 'yes'){
 		if ( $service->is_active() ) {
-			$tags[] = 'modules/recaptcha/script.js';
-			$tags[] = 'recaptcha/index.js';
-			$tags[] = 'recaptcha/api.js';
+			$tags[] = array(
+			    'name' => 'google-recaptcha',
+			    'category' => 'marketing',
+			    'placeholder' => 'google-recaptcha',
+			    'urls' => array('recaptcha/api.js'),
+			    'enable_placeholder' => '1'
+		    );
 		}
 	}
 	return $tags;

--- a/integrations/services/google-recaptcha.php
+++ b/integrations/services/google-recaptcha.php
@@ -3,7 +3,7 @@ defined( 'ABSPATH' ) or die( "you do not have access to this page!" );
 
 add_filter( 'cmplz_known_script_tags', 'cmplz_recaptcha_script' );
 function cmplz_recaptcha_script( $tags ) {
-	if (defined('WPCF7_VERSION') && version_compare(WPCF7_VERSION, 5.4, '>=')) return $tags;
+	if ((defined('WPCF7_VERSION') && version_compare(WPCF7_VERSION, 5.4, '>=')) && (!class_exists('IQFix_WPCF7_Deity'))) return $tags;
 
 	if (cmplz_get_value('block_recaptcha_service') === 'yes'){
 		$tags[] = array(
@@ -30,7 +30,7 @@ function cmplz_recaptcha_script( $tags ) {
 
 add_action( 'cmplz_banner_css', 'cmplz_recaptcha_css' );
 function cmplz_recaptcha_css() {
-	if (defined('WPCF7_VERSION') && version_compare(WPCF7_VERSION, 5.4, '>=')) return;
+	if ((defined('WPCF7_VERSION') && version_compare(WPCF7_VERSION, 5.4, '>=')) && (!class_exists('IQFix_WPCF7_Deity'))) return $tags;
 
 	?>
 		.cmplz-blocked-content-container.recaptcha-invisible,


### PR DESCRIPTION
This patch allows Contact Form 7 5.7+ integration and use reCaptcha placeholder when used in conjunction with ReCaptcha v2 for Contact Form 7 plugin [https://wordpress.org/plugins/wpcf7-recaptcha/](url).

If you find this patch useful, I believe the article on your website [https://complianz.io/why-the-wp-consent-api-is-important-a-case-study-with-cf7-and-recaptcha/](url) could be amended to account for such an integration.

I have tested this using Contact Form 7 version 5.7.4 and version 1.4.3 of the reCaptcha v2 plugin.

Please let me know if you need additional details.
