### PR TITLE
Add an extra clause to the `get_shortcode_page_id` mysql query.

### DIFF
--- a/documents/class-document.php
+++ b/documents/class-document.php
@@ -1682,7 +1682,7 @@ if ( ! class_exists( "cmplz_document" ) ) {
 				//ensure a transient, in case none is found. This prevents continuing requests on the page list
 				cmplz_set_transient( "cmplz_shortcode_$type-$region", 'none', HOUR_IN_SECONDS );
 				$query = $wpdb->prepare(
-					"SELECT * FROM $wpdb->posts WHERE (post_content LIKE %s OR post_content LIKE %s) AND post_status = 'publish'",
+					"SELECT * FROM $wpdb->posts WHERE (post_content LIKE %s OR post_content LIKE %s) AND post_status = 'publish' AND post_type = 'page'",
 					'%' . '[cmplz-document' . '%',
 					'%' . 'wp:complianz\/document' . '%'
 				);


### PR DESCRIPTION
A site was lagging out significantly since updating to v7.1.0 yesterday, and I believe it was due to the pseudo-transient in the options table running out, and execution time limits being hit by this 16 second query.

This should significantly narrow down the scope of records that it has to churn through when using multiple LIKE queries against a non-indexed column.

The query was taking over 16 seconds to run on a site I was helping to debug, and adding this brought the query down to 0.0329 seconds.

Limiting it to only the 'page' post type I assume is acceptable, as prior to v7.1.0, it had instead been running

```
get_pages(
		[
				'post_status' => ['publish','draft']
		]
);
```

As the new code no longer supports drafts, I didn't try to add that back in either.